### PR TITLE
Abrupt change in data length is causing grid.page greater then grid.lastPage

### DIFF
--- a/source/bs-table.js
+++ b/source/bs-table.js
@@ -82,12 +82,12 @@ angular.module("bsTable", [])
                         // set last page
                         grid.lastPage = Math.ceil(totalRows / grid.pageSize);
 
-						//handle abrupt change in data length (causing grid.page greater then grid.lastPage)
+                        //handle abrupt change in data length (causing grid.page greater then grid.lastPage)
                         if((grid.lastPage !== 0) && (grid.lastPage < grid.page)){
-                        	grid.page = 1;
-							grid.skipAt = (grid.page - 1) * grid.pageSize;
-						}
-						
+                            grid.page = 1;
+                            grid.skipAt = (grid.page - 1) * grid.pageSize;
+                        }
+                        
                         // recreate pagination
                         RenderPagination();
                     });

--- a/source/bs-table.js
+++ b/source/bs-table.js
@@ -82,6 +82,12 @@ angular.module("bsTable", [])
                         // set last page
                         grid.lastPage = Math.ceil(totalRows / grid.pageSize);
 
+						//handle abrupt change in data length (causing grid.page greater then grid.lastPage)
+                        if((grid.lastPage !== 0) && (grid.lastPage < grid.page)){
+                        	grid.page = 1;
+							grid.skipAt = (grid.page - 1) * grid.pageSize;
+						}
+						
                         // recreate pagination
                         RenderPagination();
                     });


### PR DESCRIPTION
When i change greater dataset to another dataset less than first, grid.page may be greater than grid.lastPage, causing zero lines on selected data range, with no selected page (on pagination).